### PR TITLE
Auto update chat function

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,5 @@
 $(function() {
-
+  
   // ------------------------関数定義----------------------------------
   function buildHTML(message){
     // メッセージに画像が含まれている場合の処理
@@ -84,4 +84,54 @@ $(function() {
     });
     return false;
   });
+
+// ------------------------チャット自動更新機能-----------------------------------
+
+  var reloadMessages = function() {
+    // jQueryのオブジェクトの指定方法 ":last" 
+    // .messageというクラスがつけられた全てのノードのうち一番最後のノードを取得
+    // つまり、カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    last_message_id = $('.message:last').data("message-id");
+    // console.log(last_message_id); //値取得確認用
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      // 自動でスクロールされるように、if文でmessageが0件意外の場合は実行するようにする
+      if (messages.length !== 0) {
+        // console.log('success'); //確認用
+        //追加するHTMLの入れ物を作る
+        var insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        //メッセージが入ったHTMLに、入れ物ごと追加
+        $('.messages').append(insertHTML);
+        //自動スクロール機能を付加。animateを使う。
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        $("#new_message")[0].reset(); //フォームの中身を空にして再度送信できるようにする処理
+        $(".form__submit").prop("disabled", false);
+      }
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
+  // setInterval
+  // 第一引数に動かしたい関数名を、第二引数に動かす間隔をミリ秒単位で渡すことができる
+  // 7秒毎に処理を繰り返す
+  // グループのメッセージ一覧ページを表示している時だけ自動更新が行われるよう処理
+  // matchはメソッドを利用した文字列にその正規表現とマッチする部分があれば、
+  // それを含む配列を返り値とする
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
+
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,16 @@
+# WebAPIの作成
+# APIはアプリケーション開発者が外部に向けてアプリケーションの機能の一部を公開する仕組み
+# WebAPIは、HTTPやHTTPS通信を通じて利用するAPIのこと
+
+# Rubyのクラス名は::で繋げて装飾できる。名前空間またはnamespaceと呼ぶ。
+# 名前空間を使うと同様のクラス名で名付けたクラスを作ってもそれらを区別することができる
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,10 @@
+# チャット自動更新用のjbuilderを作成
+# メッセージは複数投稿されている可能性があるため、配列形式でarray!メソッドを使用
+
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,11 +1,11 @@
-.message
+.message{data: {message: {id: message.id}}}
   .upper-info
     .upper-info__talker
       = message.user.name
     .upper-info__post-time
       = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
   .post-message
-    .post-message__content
+    .post-message__contente
       - if message.content.present?
         %p.post-message__content
           = message.content

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,7 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+
+#チャット自動更新用のデータ追加
+#idもデータとしてjavascriptファイルに渡す
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,13 @@ Rails.application.routes.draw do
     #投稿されたメッセージの一覧表示 & メッセージの入力ができる:index
     #メッセージの保存を行う:create
     resources :messages, only: [:index, :create]
+
+    # チャット自動更新用のapiのためのルーティング
+    # namespaceを使用した書き方
+    # ディレクトリ内(apiフォルダ)のコントローラのアクションを指定できる
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 
 end


### PR DESCRIPTION
# What
- chat-spaceアプリのメッセージの自動更新機能を追加。

# Why
- 非同期通信でメッセージを送信しているので、自分以外のユーザーはリロードを実行しないと送ったメッセージが表示されないため。

# How
- メッセージのidを取得できるようにカスタムデータ属性をmessageクラスに付与
- api通信用のメッセージコントローラ作成
- api通信用コントローラのためのルーティングを記述
- message idと、messageの中で最も大きいid取得のため、jbuilderにmessage idを追加
- js fileにコントローラから受け取ったid情報を使ってlast messageを自動更新で表示できるように記述。
- グループのメッセージ一覧画面のみ処理を実行するように記述。